### PR TITLE
github: add LOLIN S3 mini support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,6 +77,11 @@ jobs:
             chip: ESP32-S2
             fqbn: esp32:esp32:lolin_s2_mini
             name: LOLIN-S2-mini
+          - board: lolin_s3_mini
+            addr_bootloader: 0x0
+            chip: ESP32-S3
+            fqbn: esp32:esp32:lolin_s3_mini
+            name: LOLIN-S3-mini
 
     steps:
       - name: Check out code


### PR DESCRIPTION
This is completely untested since I haven't got the HW, but it might be interesting since it's dual core as opposed to ESP32-C3 and ESP32-S2, which are single core.
I will probably order one for my projects and test it when I receive it.