### PR TITLE
treewide: fix warnings

### DIFF
--- a/ConfigFile.cpp
+++ b/ConfigFile.cpp
@@ -372,7 +372,6 @@ bool ShadeConfigFile::getAppVersion(appver_t &ver) {
   char app[15];
   if(!LittleFS.exists("/appversion")) return false;
   File f = LittleFS.open("/appversion", "r");
-  size_t fsize = f.size();
   memset(app, 0x00, sizeof(app));
   f.read((uint8_t *)app, sizeof(app) - 1);
   f.close();

--- a/SSDP.cpp
+++ b/SSDP.cpp
@@ -133,7 +133,7 @@ void UPNPDeviceType::setChipId(uint32_t chipId) {
     (uint16_t)((chipId >> 8) & 0xff),
     (uint16_t)chipId & 0xff);    
 }
-SSDPClass::SSDPClass():sendQueue{NULL} {}
+SSDPClass::SSDPClass():sendQueue{false, INADDR_NONE, 0, nullptr, false, 0, ""} {}
 SSDPClass::~SSDPClass() { end(); }
 bool SSDPClass::begin() { 
   for(int i = 0; i < SSDP_QUEUE_SIZE; i++) {

--- a/Somfy.h
+++ b/Somfy.h
@@ -69,6 +69,17 @@ typedef enum {
 } t_status;
 
 struct somfy_rx_t {
+    void clear() {
+      this->status = t_status::waiting_synchro;
+      this->bit_length = 56;
+      this->cpt_synchro_hw = 0;
+      this->cpt_bits = 0;
+      this->previous_bit = 0;
+      this->waiting_half_symbol = false;
+      memset(this->payload, 0, sizeof(this->payload));
+      memset(this->pulses, 0, sizeof(this->pulses));
+      this->pulseCount = 0;
+    }
     t_status status;
     uint8_t bit_length = 56;
     uint8_t cpt_synchro_hw = 0;
@@ -91,13 +102,25 @@ struct somfy_rx_queue_t {
   bool pop(somfy_rx_t *rx);
 };
 struct somfy_tx_t {
+  void clear() {
+    this->await = 0;
+    this->cmd = somfy_commands::Unknown0;
+    this->repeats = 0;
+  }
   uint32_t await = 0;
   somfy_commands cmd;
   uint8_t repeats;
 };
 struct somfy_tx_queue_t {
-  somfy_tx_queue_t() { memset(this->index, 255, MAX_TX_BUFFER); memset(&this->items[0], 0x00, sizeof(somfy_tx_queue_t) * MAX_TX_BUFFER); }
-  void clear() { memset(&this->index[0], 255, MAX_TX_BUFFER); memset(&this->items[0], 0x00, sizeof(somfy_tx_queue_t) * MAX_TX_BUFFER); }
+  somfy_tx_queue_t() {
+    this->clear();
+  }
+  void clear() {
+    for (uint8_t i = 0; i < MAX_TX_BUFFER; i++) {
+      this->index[i] = 255;
+      this->items[i].clear();
+    }
+  }
   uint8_t length = 0;
   uint8_t index[MAX_TX_BUFFER];
   somfy_tx_t items[MAX_TX_BUFFER];

--- a/Web.cpp
+++ b/Web.cpp
@@ -229,7 +229,7 @@ void Web::begin() {
       Serial.print("Received:");
       Serial.println(apiServer.arg("plain"));
       // Send the command to the shade.
-      if(target >= 0 && target <= 100)
+      if(target <= 100)
         shade->moveToTiltTarget(target);
       else
         shade->sendTiltCommand(command);


### PR DESCRIPTION
Some of these warnings had already been fixed in https://github.com/rstrouse/ESPSomfy-RTS/pull/59, but were reverted in f850cc0a1ea96c97db706df5c14f09fc7855741a