### PR TITLE
Use 80-bit commands for tilt and stop + fix in somfy_frame_t::copy

### DIFF
--- a/Somfy.cpp
+++ b/Somfy.cpp
@@ -3009,10 +3009,10 @@ void SomfyShade::moveToTiltTarget(float target) {
   uint8_t step = 1;
   if(target < this->currentTiltPos){
       cmd = somfy_commands::StepUp; //Converted to somfy_commands::Up in sendCommand for non-80-bits shades
-      step = (this->currentTiltPos - target) * this->tiltTime / this->stepSize / 100;
+      if (this->stepSize > 0) step = (this->currentTiltPos - target) * this->tiltTime / this->stepSize / 100;
   } else if(target > this->currentTiltPos){
       cmd = somfy_commands::StepDown; //Converted to somfy_commands::Down in sendCommand for non-80-bits shades
-      step = (target - this->currentTiltPos) * this->tiltTime / this->stepSize / 100;
+      if (this->stepSize > 0) step = (target - this->currentTiltPos) * this->tiltTime / this->stepSize / 100;
   }
   if(target >= 0.0f && target <= 100.0f) {
     // Only send a command if the lift is not moving.

--- a/Somfy.cpp
+++ b/Somfy.cpp
@@ -3052,10 +3052,10 @@ void SomfyShade::moveToTarget(float pos, float tilt) {
     pos = 100;
     if(tilt < this->currentTiltPos) {
       cmd = somfy_commands::StepUp; //Converted to somfy_commands::Up in sendCommand for non-80-bits shades
-      step = (this->currentTiltPos - tilt) * this->tiltTime / this->stepSize / 100;
+      if (this->stepSize > 0) step = (this->currentTiltPos - tilt) * this->tiltTime / this->stepSize / 100;
       } else if(tilt > this->currentTiltPos) {
       cmd = somfy_commands::StepDown; //Converted to somfy_commands::Down in sendCommand for non-80-bits shades
-      step = (tilt - this->currentTiltPos) * this->tiltTime / this->stepSize / 100;
+      if (this->stepSize > 0) step = (tilt - this->currentTiltPos) * this->tiltTime / this->stepSize / 100;
     }
   }
   else {
@@ -3065,10 +3065,10 @@ void SomfyShade::moveToTarget(float pos, float tilt) {
       cmd = somfy_commands::Down;
     else if(tilt >= 0 && tilt < this->currentTiltPos){
       cmd = somfy_commands::StepUp; //Converted to somfy_commands::Up in sendCommand for non-80-bits shades
-      step = (this->currentTiltPos - tilt) * this->tiltTime / this->stepSize / 100;
+      if (this->stepSize > 0) step = (this->currentTiltPos - tilt) * this->tiltTime / this->stepSize / 100;
       } else if(tilt >= 0 && tilt > this->currentTiltPos){
       cmd = somfy_commands::StepDown; //Converted to somfy_commands::Down in sendCommand for non-80-bits shades
-      step = (tilt - this->currentTiltPos) * this->tiltTime / this->stepSize / 100;
+      if (this->stepSize > 0) step = (tilt - this->currentTiltPos) * this->tiltTime / this->stepSize / 100;
     }
   }
   if(cmd != somfy_commands::Stop) {


### PR DESCRIPTION
For motors that tilt quickly, it is necessary to use the 80-bit StepUp, StepDown and stop commands to avoid the shade accidentally being sent to the my position. The PR implements this if 80-bit frames are used. Also corrected a missing copy of stepSize in somfy_frame_t::copy